### PR TITLE
Added a travis config and test launcher script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+sudo: required
+dist: trusty
+language: python
+python:
+ - "2.7"
+# Install mongo 2.6
+before_install:
+ - "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10"
+ - "echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list"
+ - "sudo apt-get update"
+ - "sudo apt-get install mongodb-org-server mongodb-org-shell mongodb-org-tools"
+# Install python dependencies
+install:
+ - pip install --upgrade pip
+ - pip install -r requirements.txt
+# Wait for mongo to start, and then create the socaster user "eve"
+before_script: |
+    until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done
+    mongo socaster --eval 'db.createUser({"user": "eve", "roles": [{"role": "userAdmin", "db": "socaster"},{"role": "dbAdmin", "db": "socaster"},{"role": "readWrite", "db": "socaster"}], pwd: "api service access"})'
+
+# Run the server and the tests
+script: python run_server_and_tests.py
+
+# Delete these lines to get email alerts when a build fails.
+notifications:
+  email: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+setproctitle
+tornado
+yampy
+eve

--- a/run.py
+++ b/run.py
@@ -53,7 +53,9 @@ def restrict_access(resource, request, lookup):
     fields = get_list_field(resource, 'restrict_access')
     if not fields or 'admin' in g.user['roles']: return #admins can read anything
 
-    #restrict results to only those the user is allowed to read
+    # filters out results that don't match one of the 6 conditions for each
+    # field. The field named by 'restrict_access' (usually the "user" field)
+    # must match the logged in user's email or id, or be set to "public"
     lookup['$or'] = []
     for field in fields:
         lookup['$or'].extend([

--- a/run_server_and_tests.py
+++ b/run_server_and_tests.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+import subprocess,time,sys,threading
+
+"""
+This script runs both the server (run.py) and the tests (tests.py). It first
+launches the server, waits a couple seconds for it to start, and then runs
+the tests.
+
+It is mainly meant for use in a CI environment. Since output (and errors)
+from both the server and the tests is written simultaneously to stdout,
+each line is prefixed with SERVER for lines from the server, and TESTS for
+lines from the tests.
+
+Note that because the server and the tests run in parallel, the order of the
+outputs may not always be the actual order of execution. Expect to see things
+like errors in the tests before the request is shown in the server.
+"""
+
+def print_output(prefix, pipe):
+    for line in pipe:
+        print("{}: {}".format(prefix, line), end="")
+
+if __name__ == "__main__":
+    print("Launching server")
+    server = subprocess.Popen(["python", "run.py"],
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.STDOUT)
+    t1 = threading.Thread(target=print_output,
+                          args=("SERVER", server.stdout))
+    t1.start()
+    time.sleep(2)
+
+    if server.poll() is not None:
+        print("Server didn't start correctly")
+        sys.exit(1)
+
+    print("Server launched. Running tests.")
+    try:
+        tests = subprocess.Popen(["python", "tests.py"],
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT)
+        t2 = threading.Thread(target=print_output,
+                              args=("TESTS", tests.stdout))
+        t2.start()
+        sys.exit(tests.wait())
+    finally:
+        print("Killing server")
+        server.kill()


### PR DESCRIPTION
This is the squashed commit from the changes I made, mostly to get a working travis config. The commit message is below.

---

The travis config installs mongo2.6 and adds the 'eve' user to the database
before running the tests.

A script run_server_and_tests.py runs the server (run.py) and then in parallel
launches the tests (tests.py), and shuts down the server when finished. The
travis config uses this to run the tests in the CI environment.

Also added a requirements.txt file

Finally, clarified a comment about access control
